### PR TITLE
Feat/parametric messagepack version

### DIFF
--- a/sample/test-gateway-aot.sh
+++ b/sample/test-gateway-aot.sh
@@ -103,7 +103,7 @@ cat > "$SMOKE_ROOT/Gateway.Aot.Smoke.csproj" <<EOF
   </PropertyGroup>
 
   <ItemGroup>
-  <PackageReference Include="MessagePack" Version="3.1.4" />
+  <PackageReference Include="MessagePack" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/yaver-codegen/src/main/java/dev/yaver/codegen/YaverCsGateway.java
+++ b/yaver-codegen/src/main/java/dev/yaver/codegen/YaverCsGateway.java
@@ -126,6 +126,7 @@ public class YaverCsGateway extends AbstractCSharpCodegen {
     protected static final String YAVER_RESULT_VERSION = "yaverResultVersion";
     protected static final String SPLIT_SCHEMAS = "splitSchemas";
     protected static final String FLUENT_VALIDATION_VERSION = "fluentValidationVersion";
+    protected static final String MESSAGEPACK_VERSION = "messagePackVersion";
     protected static final String SCHEMAS_PACKAGE_NAME = "schemasPackageName";
 
     @SuppressWarnings("hiding")
@@ -173,6 +174,7 @@ public class YaverCsGateway extends AbstractCSharpCodegen {
     protected String yaverResultVersion = "2.1.0";
     protected boolean splitSchemas = false;
     protected String fluentValidationVersion = "12.1.1";
+    protected String messagePackVersion = "3.1.7";
     protected String schemasPackageName = null;
 
     public YaverCsGateway() {
@@ -277,6 +279,10 @@ public class YaverCsGateway extends AbstractCSharpCodegen {
         addOption(FLUENT_VALIDATION_VERSION,
                 "FluentValidation NuGet package version (used when splitSchemas=true).",
                 this.fluentValidationVersion);
+
+        addOption(MESSAGEPACK_VERSION,
+                "MessagePack NuGet package version.",
+                this.messagePackVersion);
 
         addSwitch(SPLIT_SCHEMAS,
                 "When true, generates a separate Schemas csproj for models/enums/validators without FastEndpoints dependency.",
@@ -723,6 +729,11 @@ public class YaverCsGateway extends AbstractCSharpCodegen {
             this.fluentValidationVersion = additionalProperties.get(FLUENT_VALIDATION_VERSION).toString();
         }
         additionalProperties.put(FLUENT_VALIDATION_VERSION, this.fluentValidationVersion);
+
+        if (additionalProperties.containsKey(MESSAGEPACK_VERSION)) {
+            this.messagePackVersion = additionalProperties.get(MESSAGEPACK_VERSION).toString();
+        }
+        additionalProperties.put(MESSAGEPACK_VERSION, this.messagePackVersion);
 
         if (this.splitSchemas) {
             this.schemasPackageName = packageName.replace(".Features", ".Schemas");

--- a/yaver-codegen/src/main/resources/yaver-cs-gateway/netcore_project.mustache
+++ b/yaver-codegen/src/main/resources/yaver-cs-gateway/netcore_project.mustache
@@ -25,6 +25,7 @@
     <FastEndpointsVersion>{{fastEndpointsVersion}}</FastEndpointsVersion>
     <RiokMapperlyVersion>{{riokMapperlyVersion}}</RiokMapperlyVersion>
     <YaverResultVersion>{{yaverResultVersion}}</YaverResultVersion>
+    <MessagePackVersion>{{messagePackVersion}}</MessagePackVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
@@ -34,8 +35,8 @@
 		<PackageReference Include="FastEndpoints" Version="$(FastEndpointsVersion)" />
     <PackageReference Include="FastEndpoints.Messaging.Core" Version="$(FastEndpointsVersion)"/>
     <PackageReference Include="FastEndpoints.Messaging.Remote" Version="$(FastEndpointsVersion)"/>
-    <PackageReference Include="MessagePack" Version="3.1.4" />
-    <PackageReference Include="MessagePack.Annotations" Version="3.1.4" />
+    <PackageReference Include="MessagePack" Version="$(MessagePackVersion)" />
+    <PackageReference Include="MessagePack.Annotations" Version="$(MessagePackVersion)" />
     <PackageReference Include="FastEndpoints.Generator" Version="$(FastEndpointsVersion)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/yaver-codegen/src/main/resources/yaver-cs-gateway/netcore_schemas_project.mustache
+++ b/yaver-codegen/src/main/resources/yaver-cs-gateway/netcore_schemas_project.mustache
@@ -8,6 +8,7 @@
     <Nullable>annotations</Nullable>
     <NoWarn>1591</NoWarn>
     <FluentValidationVersion>{{fluentValidationVersion}}</FluentValidationVersion>
+    <MessagePackVersion>{{messagePackVersion}}</MessagePackVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
@@ -16,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="$(FluentValidationVersion)" />
-    <PackageReference Include="MessagePack" Version="3.1.4" />
-    <PackageReference Include="MessagePack.Annotations" Version="3.1.4" />
+    <PackageReference Include="MessagePack" Version="$(MessagePackVersion)" />
+    <PackageReference Include="MessagePack.Annotations" Version="$(MessagePackVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/yaver-codegen/src/main/resources/yaver-cs-gateway/rest-mapper.mustache
+++ b/yaver-codegen/src/main/resources/yaver-cs-gateway/rest-mapper.mustache
@@ -15,7 +15,9 @@ public static partial class {{operationIdCamelCase}}RequestMapper
   /// </summary>
   /// <param name="source">API {{operationIdCamelCase}}Request model</param>
   /// <returns>Service {{operationIdCamelCase}} model</returns>
+#pragma warning disable RMG066
   public static partial {{operationIdCamelCase}}Command ToCommand(this {{operationIdCamelCase}}Request source);
+#pragma warning restore RMG066
 
   {{#formParams}}
   {{#isFile}}

--- a/yaver-codegen/src/main/resources/yaver-proxy/rest-mapper.mustache
+++ b/yaver-codegen/src/main/resources/yaver-proxy/rest-mapper.mustache
@@ -16,7 +16,9 @@ public static partial class {{operationIdCamelCase}}RequestMapper
   /// </summary>
   /// <param name="source">API {{operationIdCamelCase}}Request model</param>
   /// <returns>Service {{operationIdCamelCase}} model</returns>
+#pragma warning disable RMG066
   public static partial {{operationIdCamelCase}}Command ToCommand(this {{operationIdCamelCase}}Request source);
+#pragma warning restore RMG066
 
   private static FileData Map(IFormFile file) => FileMappingBaseMapper.Map(file);
 }


### PR DESCRIPTION
This pull request updates the handling of the `MessagePack` NuGet package version in the C# gateway code generation. The main improvement is making the `MessagePack` version configurable via the generator, ensuring consistency across generated projects and templates. Additionally, a minor code generation warning is suppressed in the generated mapper classes.

**NuGet package version management:**

* Added support for configuring the `MessagePack` NuGet package version in the code generator by introducing the `messagePackVersion` option in `YaverCsGateway.java` and making it available in templates. [[1]](diffhunk://#diff-be48cf989209b5df4e861b1954255c78b3825af87223cff2bdf8418db26c8afaR129) [[2]](diffhunk://#diff-be48cf989209b5df4e861b1954255c78b3825af87223cff2bdf8418db26c8afaR177) [[3]](diffhunk://#diff-be48cf989209b5df4e861b1954255c78b3825af87223cff2bdf8418db26c8afaR283-R286) [[4]](diffhunk://#diff-be48cf989209b5df4e861b1954255c78b3825af87223cff2bdf8418db26c8afaR733-R737)
* Updated project templates (`netcore_project.mustache`, `netcore_schemas_project.mustache`) to use the configurable `MessagePackVersion` property instead of hardcoded values, and updated the default version to `3.1.7`. [[1]](diffhunk://#diff-48615f4faeff0feacf127b3fea8dda15ae443cb284fadeb76c083e90ab202f68R28) [[2]](diffhunk://#diff-48615f4faeff0feacf127b3fea8dda15ae443cb284fadeb76c083e90ab202f68L37-R39) [[3]](diffhunk://#diff-7e3ba67067165fa4686bc5aace55fe6a82e699b934229e4acdba7c1a05642efdR11) [[4]](diffhunk://#diff-7e3ba67067165fa4686bc5aace55fe6a82e699b934229e4acdba7c1a05642efdL19-R21)
* Updated the test project to use `MessagePack` version `3.1.7`.

**Code generation quality:**

* Suppressed the `RMG066` warning in generated REST mapper classes to avoid unnecessary warnings in generated code. [[1]](diffhunk://#diff-9ebc3b34fd4e395dc7e3ddeded9555cbb47bd3aace00e3a0f1b3c371ad02151bR18-R20) [[2]](diffhunk://#diff-22a36c56a4f5b3f0bc4e1b1884e5e061f7e12c5dce0441f7aaa7495f0ba720aaR19-R21)