### PR TITLE
fix(proxy): honor declared success status codes

### DIFF
--- a/run-all.sh
+++ b/run-all.sh
@@ -14,5 +14,6 @@ echo "🔨 Building yaver-generator..."
 echo "🚀 Running proxy test..."
 cd sample
 ./test-proxy.sh
+./test-proxy-success-statuses.sh
 # ./test-fastendpoints.sh
 echo "✅ All tasks completed successfully!"

--- a/sample/fixtures/proxy-success-statuses.yaml
+++ b/sample/fixtures/proxy-success-statuses.yaml
@@ -1,0 +1,72 @@
+openapi: 3.0.3
+info:
+  title: Proxy success status regression
+  version: 1.0.0
+tags:
+  - name: Status
+paths:
+  /status/ok:
+    get:
+      tags:
+        - Status
+      operationId: getStatus
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+  /status/created:
+    post:
+      tags:
+        - Status
+      operationId: createStatus
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+  /status/accepted:
+    post:
+      tags:
+        - Status
+      operationId: acceptStatus
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+  /status/partial:
+    get:
+      tags:
+        - Status
+      operationId: getPartialStatus
+      responses:
+        "206":
+          description: Partial content
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+  /status/no-content:
+    delete:
+      tags:
+        - Status
+      operationId: deleteStatus
+      responses:
+        "204":
+          description: No content
+components:
+  schemas:
+    StatusResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string

--- a/sample/test-proxy-success-statuses.sh
+++ b/sample/test-proxy-success-statuses.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/proxy-success-statuses.yaml"
+OPENAPI_GENERATOR_JAR="$ROOT_DIR/cli/openapi-generator-cli.jar"
+YAVER_GENERATOR_JAR="${YAVER_GENERATOR_JAR:-$ROOT_DIR/yaver-codegen/target/yaver-codegen.jar}"
+OUTPUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/yaver-proxy-success-statuses.XXXXXX")"
+
+cleanup() {
+  rm -rf "$OUTPUT_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$YAVER_GENERATOR_JAR" ]]; then
+  echo "Generator JAR not found: $YAVER_GENERATOR_JAR" >&2
+  echo "Build it with: mvn -f yaver-codegen/pom.xml clean package" >&2
+  exit 2
+fi
+
+java -cp "$YAVER_GENERATOR_JAR:$OPENAPI_GENERATOR_JAR" \
+  org.openapitools.codegen.OpenAPIGenerator \
+  generate \
+  -g yaver-proxy \
+  -i "$FIXTURE" \
+  -o "$OUTPUT_DIR" \
+  --additional-properties=packageName=Yaver.Proxy.StatusCodes \
+  --additional-properties=targetFramework=net10.0 \
+  --additional-properties=fastEndpointsVersion=7.1.1 \
+  --additional-properties=riokMapperlyVersion=4.3.0 \
+  --additional-properties=yaverResultVersion=1.1.0
+
+API_FILE="$(find "$OUTPUT_DIR/src" -type f -name 'StatusApi.cs' -print -quit)"
+PROJECT_FILE="$(find "$OUTPUT_DIR/src" -type f -name '*.csproj' -print -quit)"
+
+if [[ -z "$API_FILE" || -z "$PROJECT_FILE" ]]; then
+  echo "Expected generated API and project files were not found." >&2
+  exit 1
+fi
+
+assert_contains() {
+  local expected="$1"
+  if ! grep -Fq "$expected" "$API_FILE"; then
+    echo "Expected generated status mapping was not found: $expected" >&2
+    exit 1
+  fi
+}
+
+assert_contains ".SendAsync(HttpContext, 200, ct)"
+assert_contains ".SendAsync(HttpContext, 201, ct)"
+assert_contains ".SendAsync(HttpContext, 202, ct)"
+assert_contains ".SendAsync(HttpContext, 206, ct)"
+assert_contains "await Send.NoContentAsync(ct).ConfigureAwait(false);"
+assert_contains ".SendAsync(HttpContext, cancellationToken: ct)"
+
+if grep -Fq ".SendAsync(HttpContext, 204, ct)" "$API_FILE"; then
+  echo "A 204 success response must not serialize a response body." >&2
+  exit 1
+fi
+
+dotnet build "$PROJECT_FILE" -c Release --nologo
+
+echo "Proxy success status regression OK"

--- a/yaver-codegen/src/main/java/dev/yaver/codegen/YaverProxyCodegen.java
+++ b/yaver-codegen/src/main/java/dev/yaver/codegen/YaverProxyCodegen.java
@@ -1323,6 +1323,9 @@ public class YaverProxyCodegen extends AbstractCSharpCodegen {
 
             if (successResponse != null) {
                 op.vendorExtensions.put("hasSuccessResponse", true);
+                op.vendorExtensions.put("successResponseCode",
+                        successResponse.code != null && !successResponse.code.isEmpty() ? successResponse.code : "200");
+                op.vendorExtensions.put("successResponseNoContent", "204".equals(successResponse.code));
 
                 // Get response data type from different sources
                 String responseModel = getResponseDataType(successResponse);

--- a/yaver-codegen/src/main/resources/yaver-proxy/rest-endpoint.mustache
+++ b/yaver-codegen/src/main/resources/yaver-proxy/rest-endpoint.mustache
@@ -51,11 +51,31 @@ public class {{operationIdCamelCase}}Endpoint:Endpoint<
 		{{/bodyParam}}
 	}
 	//{{#hasParams}}{{operationIdCamelCase}}Request{{/hasParams}}{{^hasParams}}EmptyRequest{{/hasParams}}
+	{{#vendorExtensions.successResponseNoContent}}
+	public override async Task HandleAsync({{operationIdCamelCase}}Request req, CancellationToken ct)
+	{
+		var result = await req.ToCommand()
+			.RemoteExecuteAsync(ct)
+			.ConfigureAwait(false);
+
+		if (result.Status == Yaver.Result.ResultStatus.Ok)
+		{
+			await Send.NoContentAsync(ct).ConfigureAwait(false);
+			return;
+		}
+
+		await result
+			.SendAsync(HttpContext, cancellationToken: ct)
+			.ConfigureAwait(false);
+	}
+	{{/vendorExtensions.successResponseNoContent}}
+	{{^vendorExtensions.successResponseNoContent}}
 	public override async Task HandleAsync({{operationIdCamelCase}}Request req, CancellationToken ct) =>
 	await req.ToCommand()
 		.RemoteExecuteAsync(ct)
-		.SendAsync(HttpContext, 200, ct)
+		.SendAsync(HttpContext, {{#vendorExtensions.successResponseCode}}{{vendorExtensions.successResponseCode}}{{/vendorExtensions.successResponseCode}}{{^vendorExtensions.successResponseCode}}200{{/vendorExtensions.successResponseCode}}, ct)
 		.ConfigureAwait(false);
+	{{/vendorExtensions.successResponseNoContent}}
 }
 
 {{^hasParams}}


### PR DESCRIPTION
## What changed

- emit the exact successful response code declared by the OpenAPI operation instead of always returning `200`
- return a bodyless FastEndpoints response for `204` while preserving normal error mapping
- add a generator fixture covering `200`, `201`, `202`, `204`, and `206`
- build the generated .NET project as part of the proxy regression script

## Why

`yaver-proxy` discovered the successful OpenAPI response model but discarded its status code. The generated endpoint template therefore hardcoded `200`, including for create operations declared as `201`.

This is a focused maintenance fix for the `v0.21` line used by `Opis.BranchOps.Features`.

## Validation

- `mvn -f yaver-codegen/pom.xml clean package`
- `sample/test-proxy-success-statuses.sh`
- generated project builds with FastEndpoints `7.1.1` and Yaver.Result `1.1.0`
- current BranchOps 1.0.5 spec generated with the patched `v0.21` code: only the three OAS-declared create responses changed from `200` to `201`

Related finding: https://github.com/albaarcade/opis-pjm/issues/268
